### PR TITLE
Add Monado inventories for additional platforms

### DIFF
--- a/runtimes/monado_android.json
+++ b/runtimes/monado_android.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "../schema.json",
+    "name": "Monado (Android)",
+    "vendor": "Monado Community + Collabora, Ltd.",
+    "platform": "Android (Phone/Installable)",
+    "conformance_notes": "Only the 'Simulated Device' in Monado on Linux is officially conformant. Vendors building on Monado must follow the normal conformance process for their own devices.",
+    "notes": "Could be built-in to an all-in-one, but Collabora does not manufacture or have system-level access to such devices",
+    "extensions": [
+        "XR_KHR_android_create_instance",
+        "XR_KHR_composition_layer_cube",
+        "XR_KHR_composition_layer_cylinder",
+        "XR_KHR_composition_layer_depth",
+        "XR_KHR_composition_layer_equirect",
+        "XR_KHR_composition_layer_equirect2",
+        "XR_KHR_convert_timespec_time",
+        "XR_KHR_loader_init",
+        "XR_KHR_loader_init_android",
+        "XR_KHR_opengl_es_enable",
+        "XR_KHR_swapchain_usage_input_attachment_bit",
+        "XR_KHR_vulkan_enable",
+        "XR_KHR_vulkan_enable2",
+        "XR_EXT_hand_tracking",
+        "XR_MND_headless",
+        "XR_MND_swapchain_usage_input_attachment_bit",
+        "XR_EXTX_overlay",
+        "XR_MNDX_egl_enable"
+    ],
+    "form_factors": [
+        {
+            "form_factor": "XR_FORM_FACTOR_HEAD_MOUNTED_DISPLAY",
+            "view_configurations": [
+                {
+                    "view_configuration": "XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO",
+                    "environment_blend_modes": [
+                        "OPAQUE",
+                        "ADDITIVE"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/runtimes/monado_android.json.license
+++ b/runtimes/monado_android.json.license
@@ -1,0 +1,2 @@
+Copyright 2022, The Khronos Group Inc.
+SPDX-License-Identifier: CC-BY-4.0

--- a/runtimes/monado_windows.json
+++ b/runtimes/monado_windows.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "../schema.json",
+    "name": "Monado (Windows)",
+    "vendor": "Monado Community + Collabora, Ltd.",
+    "platform": "Windows (Desktop)",
+    "conformance_notes": "Only the 'Simulated Device' in Monado on Linux is officially conformant. Vendors building on Monado must follow the normal conformance process for their own devices.",
+    "notes": "Availability of some extensions is determined by availability of dependencies at compile time.",
+    "extensions": [
+        "XR_KHR_composition_layer_cube",
+        "XR_KHR_composition_layer_cylinder",
+        "XR_KHR_composition_layer_depth",
+        "XR_KHR_composition_layer_equirect",
+        "XR_KHR_composition_layer_equirect2",
+        "XR_KHR_convert_timespec_time",
+        "XR_KHR_win32_convert_performance_counter_time",
+        "XR_KHR_D3D11_enable",
+        "XR_KHR_swapchain_usage_input_attachment_bit",
+        "XR_KHR_vulkan_enable",
+        "XR_KHR_vulkan_enable2",
+        "XR_EXT_hand_tracking",
+        {
+            "name": "XR_FB_display_refresh_rate",
+            "notes": "Not useful on all drivers"
+        },
+        "XR_MND_headless",
+        "XR_MND_swapchain_usage_input_attachment_bit"
+    ],
+    "form_factors": [
+        {
+            "form_factor": "XR_FORM_FACTOR_HEAD_MOUNTED_DISPLAY",
+            "view_configurations": [
+                {
+                    "view_configuration": "XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO",
+                    "environment_blend_modes": [
+                        "OPAQUE",
+                        "ADDITIVE"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/runtimes/monado_windows.json.license
+++ b/runtimes/monado_windows.json.license
@@ -1,0 +1,2 @@
+Copyright 2022, The Khronos Group Inc.
+SPDX-License-Identifier: CC-BY-4.0


### PR DESCRIPTION
I omitted these earlier because technically conformance is only submitted for Monado on Linux, using a simulated device, and I only included conformant runtimes in the published inventories. I'm not sure if it's worth including these anyway or if we don't want to permit that, as a group.

(I don't think I could quite yet run the interactive conformance tests on Windows because the simulated input isn't available yet. I could probably run it on Android, except there, the stock/basic "driver" uses the phone's IMU a-la Google Cardboard so it's slightly less simulated.)