### PR TITLE
Update valve_steamvr.json

### DIFF
--- a/runtimes/valve_steamvr.json
+++ b/runtimes/valve_steamvr.json
@@ -4,7 +4,7 @@
     "conformance_submission": 11,
     "platform": "Windows (Desktop)",
     "vendor": "Valve Corporation",
-    "notes": "Updated by @nnuber for July 21 2022",
+    "notes": "Updated by @nnuber for July 22 2022",
     "extensions": [
         "XR_KHR_binding_modification",
         "XR_KHR_composition_layer_depth",
@@ -25,7 +25,6 @@
         "XR_HTC_vive_focus3_controller_interaction",
         "XR_MND_headless",
         "XR_VALVE_analog_threshold",
-        "XR_EXTX_overlay",
         "XR_HTCX_vive_tracker_interaction",
         "XR_EXT_dpad_binding"
     ]


### PR DESCRIPTION
The overlay extension was accidentally checked in the spreadsheet when I exported the json-- We don't actually support it.