### PR TITLE
Add fixed width to support matrix to enhance readability

### DIFF
--- a/openxr_inventory/templates/extension_support.jinja2.html
+++ b/openxr_inventory/templates/extension_support.jinja2.html
@@ -30,125 +30,145 @@ table.table-sticky-col-headers thead tr {
     top: 50px;
 }
 
+th.rotate {
+  height: 170px;
+  white-space: nowrap;
+}
+
+th.rotate > div {
+  transform: rotate(-45deg);
+  width: 32px;
+  padding: 5px;
+}
+
 {% endblock style %}
 
 {% block container_contents %}
-    <section id="extensions">
+<section id="extensions">
 
-        <!-- extension toc -->
-        <div class="jumbotron row">
-            <h2 id="extensions">Extensions</h2>
-            {% for col in extensions | slice(3) %}
-            <div class="col-md-4">
-                <ul class="list-unstyled">
-                    {% for extension_name in col %}
-                    <li><a href="#{{ extension_name }}">{{ extension_name }}</a></li>
+    <!-- extension toc -->
+    <div class="jumbotron row">
+        <h2 id="extensions">Extensions</h2>
+        {% for col in extensions | slice(3) %}
+        <div class="col-md-4">
+            <ul class="list-unstyled">
+                {% for extension_name in col %}
+                <li><a href="#{{ extension_name }}">{{ extension_name }}</a></li>
+                {% endfor %}
+            </ul>
+        </div>
+        {% endfor %}
+    </div>
+
+    {% for extension_name in extensions %}
+    {% set support = extension_support[extension_name] %}
+
+    <div class="row" id="{{ extension_name }}">
+        <h3>{{ extension_name }} ({{ support | length }} runtime{{ "s" if support | length != 1 }})</h3>
+        <p>
+                <a href="https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#{{extension_name}}">Specification
+for {{ extension_name }}</a>
+        </p>
+        <ul>
+            {% for runtime, entry in support | sort %}
+            <li><a href="#{{ runtime.stub }}">{{ runtime.vendor }} - {{ runtime.name }}</a></li>
+            {% endfor %}
+        </ul>
+    </div>
+    {% endfor %}
+</section>
+
+<section>
+    <!-- runtime toc -->
+    <div id="runtimes" class="jumbotron row">
+        <h2>Runtimes</h2>
+
+        <ul class="list-unstyled">
+            {% for runtime in runtimes | sort %}
+            <li><a href="#{{ runtime.stub }}">{{ runtime.vendor }} - {{ runtime.name }}</a></li>
+            {% endfor %}
+        </ul>
+    </div>
+
+    {% for runtime in runtimes %}
+    <div class="row" id="{{ runtime.stub }}">
+        <h3>{{ runtime.name }}</h3>
+        <ul>
+            <li>Vendor: {{ runtime.vendor }}</li>
+            {% if runtime.conformance_submission %}
+            <li>Most recent conformance submission: <a href="{{runtime.conformance_submission_url}}">#{{runtime.conformance_submission}}</a></li>
+            {% endif %}
+            {% if not runtime.conformance_submission %}
+            <li><strong>Not a conformant runtime</strong></li>
+            {% endif %}
+            {% if runtime.conformance_notes %}
+            <li>Conformance notes: {{ runtime.conformance_notes }}</li>
+            {% endif %}
+                <li>Supported extensions:
+                <ul>
+                    {% for extension in runtime.extensions %}
+                    <li><a href="#{{extension.name}}">{{extension.name}}</a> {% if extension.notes %} - {{ extension.notes }} {% endif %} </li>
                     {% endfor %}
                 </ul>
-            </div>
-            {% endfor %}
-        </div>
+        </ul>
+    </div>
+    {% endfor %}
+</section>
 
-        {% for extension_name in extensions %}
-        {% set support = extension_support[extension_name] %}
-
-        <div class="row" id="{{ extension_name }}">
-            <h3>{{ extension_name }} ({{ support | length }} runtime{{ "s" if support | length != 1 }})</h3>
-            <p>
-                <a href="https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#{{extension_name}}">Specification
-                    for {{ extension_name }}</a>
-            </p>
-            <ul>
-                {% for runtime, entry in support | sort %}
-                <li><a href="#{{ runtime.stub }}">{{ runtime.vendor }} - {{ runtime.name }}</a></li>
-                {% endfor %}
-            </ul>
-        </div>
-        {% endfor %}
-    </section>
-
-    <section>
-        <!-- runtime toc -->
-        <div id="runtimes" class="jumbotron row">
-            <h2>Runtimes</h2>
-
-            <ul class="list-unstyled">
+<section>
+    <div id="matrix" class="jumbotron row">
+        <h2>Runtime support matrix</h2>
+    </div>
+        <table class="table table-hover table-condensed table-sticky-col-headers">
+        <thead>
+            <tr>
+                <th></th>
                 {% for runtime in runtimes | sort %}
-                <li><a href="#{{ runtime.stub }}">{{ runtime.vendor }} - {{ runtime.name }}</a></li>
+                {# pragmatic check if the runtime name fits in the layout or if it needs to be truncated and put the full name in tooltip #}
+                {% if runtime.name|length < 34 %}
+                <th class="rotate" style="border:none"><div><span>{{ runtime.name }}</span></div></th>
+                {% else %}
+                <th class="rotate" style="border:none"><div><span><abbr title="{{runtime.name}}">{{ runtime.name|truncate(34, True) }}</abbr></span></div></th>
+                {% endif %}
                 {% endfor %}
-            </ul>
-        </div>
+            </tr>
+        </thead>
+        <tbody>
 
-        {% for runtime in runtimes %}
-        <div class="row" id="{{ runtime.stub }}">
-            <h3>{{ runtime.name }}</h3>
-            <ul>
-                <li>Vendor: {{ runtime.vendor }}</li>
-                {% if runtime.conformance_submission %}
-                <li>Most recent conformance submission: <a href="{{runtime.conformance_submission_url}}">#{{runtime.conformance_submission}}</a></li>
+            {% macro extension_matrix_row(extension_name) %}
+            <tr>
+                <th class="extname">
+                    <span class="label label-default"></span>
+                {{ extension_name }} <a href="https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#{{extension_name}}" alt="speficication text">
+                    <span class="glyphicon glyphicon-link" aria-hidden="true"></span></a>
+                </th>
+                {% for runtime in runtimes | sort %}
+                {% if extension_name in runtime_support[runtime.name] %}
+                <td class="text-center bg-success"><span class="glyphicon glyphicon-ok" style="color:green" aria-hidden="true"></span><span class="sr-only">Supported</span></td>
+                {% else %}
+                <td class="text-center"><span class="glyphicon glyphicon-minus" style="opacity:0.1"></span><span class="sr-only">Not supported or not applicable</span></td>
                 {% endif %}
-                {% if not runtime.conformance_submission %}
-                <li><strong>Not a conformant runtime</strong></li>
-                {% endif %}
-                {% if runtime.conformance_notes %}
-                <li>Conformance notes: {{ runtime.conformance_notes }}</li>
-                {% endif %}
-                <li>Supported extensions:
-                    <ul>
-                        {% for extension in runtime.extensions %}
-                        <li><a href="#{{extension.name}}">{{extension.name}}</a> {% if extension.notes %} - {{ extension.notes }} {% endif %} </li>
-                        {% endfor %}
-                    </ul>
-            </ul>
-        </div>
-        {% endfor %}
-    </section>
-
-    <section>
-        <div id="matrix" class="jumbotron row">
-            <h2>Runtime support matrix</h2>
-        </div>
-        <table class="table table-bordered table-hover table-condensed table-sticky-col-headers">
-            <thead>
-                <tr>
-                    <th></th>
-                    {% for runtime in runtimes | sort %}
-                    <th class="runtime-name">{{ runtime.name }}</th>
-                    {% endfor %}
-                </tr>
-            </thead>
-            <tbody>
-
-                {% macro extension_matrix_row(extension_name) %}
-                <tr>
-                    <th class="extname">{{ extension_name }}</th>
-                    {% for runtime in runtimes | sort %}
-                        {% if extension_name in runtime_support[runtime.name] %}
-                        <td class="bg-success">Y <span class="sr-only">Supported</span></td>
-                        {% else %}
-                        <td><span class="sr-only">Not supported or not applicable</span></td>
-                        {% endif %}
-                    {% endfor %}
-                </tr>
-                {% endmacro %}
-
-                {# Loop through all categories of extension (KHR, EXT, vendor, KHX, EXTX, Vendor-X) #}
-                {% for c in cat.all_categories() %}
-                    {# Loop through all extensions in that category #}
-                    {% for extension_name in extensions if categorize_ext(extension_name) == c %}
-                        {% if loop.first %}
-                            {# this header is inside the loop so it is skipped if we have no items in this category #}
-                            {# it is inside this "if" so it only shows up once for each category. #}
-                            <tr>
-                                <th>{{ cat_captions[c] }} Extensions</th>
-                            </tr>
-                        {% endif %}
-                        {# Write out a row in the table for this extension #}
-                        {{ extension_matrix_row(extension_name) }}
-                    {% endfor %}
                 {% endfor %}
+            </tr>
+            {% endmacro %}
 
-            </tbody>
-        </table>
-    </section>
+            {# Loop through all categories of extension (KHR, EXT, vendor, KHX, EXTX, Vendor-X) #}
+            {% for c in cat.all_categories() %}
+            {# Loop through all extensions in that category #}
+            {% for extension_name in extensions if categorize_ext(extension_name) == c %}
+            {% if loop.first %}
+            {# this header is inside the loop so it is skipped if we have no items in this category #}
+            {# it is inside this "if" so it only shows up once for each category. #}
+            <tr class="active">
+                <th style="text-align:center" colspan="{{ runtimes|length + 1 }}">{{ cat_captions[c] }} Extensions</th>
+            </tr>
+            {% endif %}
+            {# Write out a row in the table for this extension #}
+            {{ extension_matrix_row(extension_name) }}
+            {% endfor %}
+            {% endfor %}
+
+        </tbody>
+    </table>
+</section>
 {% endblock container_contents %}

--- a/openxr_inventory/templates/extension_support.jinja2.html
+++ b/openxr_inventory/templates/extension_support.jinja2.html
@@ -44,131 +44,132 @@ th.rotate > div {
 {% endblock style %}
 
 {% block container_contents %}
-<section id="extensions">
+    <section id="extensions">
 
-    <!-- extension toc -->
-    <div class="jumbotron row">
-        <h2 id="extensions">Extensions</h2>
-        {% for col in extensions | slice(3) %}
-        <div class="col-md-4">
-            <ul class="list-unstyled">
-                {% for extension_name in col %}
-                <li><a href="#{{ extension_name }}">{{ extension_name }}</a></li>
+        <!-- extension toc -->
+        <div class="jumbotron row">
+            <h2 id="extensions">Extensions</h2>
+            {% for col in extensions | slice(3) %}
+            <div class="col-md-4">
+                <ul class="list-unstyled">
+                    {% for extension_name in col %}
+                    <li><a href="#{{ extension_name }}">{{ extension_name }}</a></li>
+                    {% endfor %}
+                </ul>
+            </div>
+            {% endfor %}
+        </div>
+
+        {% for extension_name in extensions %}
+        {% set support = extension_support[extension_name] %}
+
+        <div class="row" id="{{ extension_name }}">
+            <h3>{{ extension_name }} ({{ support | length }} runtime{{ "s" if support | length != 1 }})</h3>
+            <p>
+                <a href="https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#{{extension_name}}">Specification
+                    for {{ extension_name }}</a>
+            </p>
+            <ul>
+                {% for runtime, entry in support | sort %}
+                <li><a href="#{{ runtime.stub }}">{{ runtime.vendor }} - {{ runtime.name }}</a></li>
                 {% endfor %}
             </ul>
         </div>
         {% endfor %}
-    </div>
+    </section>
 
-    {% for extension_name in extensions %}
-    {% set support = extension_support[extension_name] %}
+    <section>
+        <!-- runtime toc -->
+        <div id="runtimes" class="jumbotron row">
+            <h2>Runtimes</h2>
 
-    <div class="row" id="{{ extension_name }}">
-        <h3>{{ extension_name }} ({{ support | length }} runtime{{ "s" if support | length != 1 }})</h3>
-        <p>
-                <a href="https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#{{extension_name}}">Specification
-for {{ extension_name }}</a>
-        </p>
-        <ul>
-            {% for runtime, entry in support | sort %}
-            <li><a href="#{{ runtime.stub }}">{{ runtime.vendor }} - {{ runtime.name }}</a></li>
-            {% endfor %}
-        </ul>
-    </div>
-    {% endfor %}
-</section>
+            <ul class="list-unstyled">
+                {% for runtime in runtimes | sort %}
+                <li><a href="#{{ runtime.stub }}">{{ runtime.vendor }} - {{ runtime.name }}</a></li>
+                {% endfor %}
+            </ul>
+        </div>
 
-<section>
-    <!-- runtime toc -->
-    <div id="runtimes" class="jumbotron row">
-        <h2>Runtimes</h2>
-
-        <ul class="list-unstyled">
-            {% for runtime in runtimes | sort %}
-            <li><a href="#{{ runtime.stub }}">{{ runtime.vendor }} - {{ runtime.name }}</a></li>
-            {% endfor %}
-        </ul>
-    </div>
-
-    {% for runtime in runtimes %}
-    <div class="row" id="{{ runtime.stub }}">
-        <h3>{{ runtime.name }}</h3>
-        <ul>
-            <li>Vendor: {{ runtime.vendor }}</li>
-            {% if runtime.conformance_submission %}
-            <li>Most recent conformance submission: <a href="{{runtime.conformance_submission_url}}">#{{runtime.conformance_submission}}</a></li>
-            {% endif %}
-            {% if not runtime.conformance_submission %}
-            <li><strong>Not a conformant runtime</strong></li>
-            {% endif %}
-            {% if runtime.conformance_notes %}
-            <li>Conformance notes: {{ runtime.conformance_notes }}</li>
-            {% endif %}
+        {% for runtime in runtimes %}
+        <div class="row" id="{{ runtime.stub }}">
+            <h3>{{ runtime.name }}</h3>
+            <ul>
+                <li>Vendor: {{ runtime.vendor }}</li>
+                {% if runtime.conformance_submission %}
+                <li>Most recent conformance submission: <a href="{{runtime.conformance_submission_url}}">#{{runtime.conformance_submission}}</a></li>
+                {% endif %}
+                {% if not runtime.conformance_submission %}
+                <li><strong>Not a conformant runtime</strong></li>
+                {% endif %}
+                {% if runtime.conformance_notes %}
+                <li>Conformance notes: {{ runtime.conformance_notes }}</li>
+                {% endif %}
                 <li>Supported extensions:
-                <ul>
-                    {% for extension in runtime.extensions %}
-                    <li><a href="#{{extension.name}}">{{extension.name}}</a> {% if extension.notes %} - {{ extension.notes }} {% endif %} </li>
-                    {% endfor %}
-                </ul>
-        </ul>
-    </div>
-    {% endfor %}
-</section>
+                    <ul>
+                        {% for extension in runtime.extensions %}
+                        <li><a href="#{{extension.name}}">{{extension.name}}</a> {% if extension.notes %} - {{ extension.notes }} {% endif %} </li>
+                        {% endfor %}
+                    </ul>
+            </ul>
+        </div>
+        {% endfor %}
+    </section>
 
-<section>
-    <div id="matrix" class="jumbotron row">
-        <h2>Runtime support matrix</h2>
-    </div>
+    <section>
+        <div id="matrix" class="jumbotron row">
+            <h2>Runtime support matrix</h2>
+        </div>
         <table class="table table-hover table-condensed table-sticky-col-headers">
-        <thead>
-            <tr>
-                <th></th>
-                {% for runtime in runtimes | sort %}
-                {# pragmatic check if the runtime name fits in the layout or if it needs to be truncated and put the full name in tooltip #}
-                {% if runtime.name|length < 34 %}
-                <th class="rotate" style="border:none"><div><span>{{ runtime.name }}</span></div></th>
-                {% else %}
-                <th class="rotate" style="border:none"><div><span><abbr title="{{runtime.name}}">{{ runtime.name|truncate(34, True) }}</abbr></span></div></th>
-                {% endif %}
+            <thead>
+                <tr>
+                    <th></th>
+                    {% for runtime in runtimes | sort %}
+                        {# pragmatic check if the runtime name fits in the layout or if it needs to be truncated and put the full name in tooltip #}
+                        {% if runtime.name|length < 34 %}
+                        <th class="rotate" style="border:none"><div><span>{{ runtime.name }}</span></div></th>
+                        {% else %}
+                        <th class="rotate" style="border:none"><div><span><abbr title="{{runtime.name}}">{{ runtime.name|truncate(34, True) }}</abbr></span></div></th>
+                        {% endif %}
+                    {% endfor %}
+                </tr>
+            </thead>
+            <tbody>
+
+                {% macro extension_matrix_row(extension_name) %}
+                <tr>
+                    <th class="extname">
+                        {{ extension_name }}
+                        <a href="https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#{{extension_name}}" alt="speficication text">
+                            <span class="glyphicon glyphicon-link" aria-hidden="true"></span>
+                        </a>
+                    </th>
+                    {% for runtime in runtimes | sort %}
+                        {% if extension_name in runtime_support[runtime.name] %}
+                        <td class="text-center bg-success"><span class="glyphicon glyphicon-ok" style="color:green" aria-hidden="true"></span><span class="sr-only">Supported</span></td>
+                        {% else %}
+                        <td class="text-center"><span class="glyphicon glyphicon-minus" style="opacity:0.1"></span><span class="sr-only">Not supported or not applicable</span></td>
+                        {% endif %}
+                    {% endfor %}
+                </tr>
+                {% endmacro %}
+
+                {# Loop through all categories of extension (KHR, EXT, vendor, KHX, EXTX, Vendor-X) #}
+                {% for c in cat.all_categories() %}
+                    {# Loop through all extensions in that category #}
+                    {% for extension_name in extensions if categorize_ext(extension_name) == c %}
+                        {% if loop.first %}
+                            {# this header is inside the loop so it is skipped if we have no items in this category #}
+                            {# it is inside this "if" so it only shows up once for each category. #}
+                            <tr class="active">
+                                <th style="text-align:center" colspan="{{ runtimes|length + 1 }}">{{ cat_captions[c] }} Extensions</th>
+                            </tr>
+                        {% endif %}
+                        {# Write out a row in the table for this extension #}
+                        {{ extension_matrix_row(extension_name) }}
+                    {% endfor %}
                 {% endfor %}
-            </tr>
-        </thead>
-        <tbody>
 
-            {% macro extension_matrix_row(extension_name) %}
-            <tr>
-                <th class="extname">
-                    <span class="label label-default"></span>
-                {{ extension_name }} <a href="https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#{{extension_name}}" alt="speficication text">
-                    <span class="glyphicon glyphicon-link" aria-hidden="true"></span></a>
-                </th>
-                {% for runtime in runtimes | sort %}
-                {% if extension_name in runtime_support[runtime.name] %}
-                <td class="text-center bg-success"><span class="glyphicon glyphicon-ok" style="color:green" aria-hidden="true"></span><span class="sr-only">Supported</span></td>
-                {% else %}
-                <td class="text-center"><span class="glyphicon glyphicon-minus" style="opacity:0.1"></span><span class="sr-only">Not supported or not applicable</span></td>
-                {% endif %}
-                {% endfor %}
-            </tr>
-            {% endmacro %}
-
-            {# Loop through all categories of extension (KHR, EXT, vendor, KHX, EXTX, Vendor-X) #}
-            {% for c in cat.all_categories() %}
-            {# Loop through all extensions in that category #}
-            {% for extension_name in extensions if categorize_ext(extension_name) == c %}
-            {% if loop.first %}
-            {# this header is inside the loop so it is skipped if we have no items in this category #}
-            {# it is inside this "if" so it only shows up once for each category. #}
-            <tr class="active">
-                <th style="text-align:center" colspan="{{ runtimes|length + 1 }}">{{ cat_captions[c] }} Extensions</th>
-            </tr>
-            {% endif %}
-            {# Write out a row in the table for this extension #}
-            {{ extension_matrix_row(extension_name) }}
-            {% endfor %}
-            {% endfor %}
-
-        </tbody>
-    </table>
-</section>
+            </tbody>
+        </table>
+    </section>
 {% endblock container_contents %}

--- a/runtimes/varjo.json
+++ b/runtimes/varjo.json
@@ -25,5 +25,27 @@
         "XR_VARJO_quad_views",
         "XR_VARJO_view_offset",
         "XR_HTCX_vive_tracker_interaction"
+    ],
+    "form_factors": [
+        {
+            "form_factor": "XR_FORM_FACTOR_HEAD_MOUNTED_DISPLAY",
+            "view_configurations": [
+                {
+                    "view_configuration": "XR_VIEW_CONFIGURATION_TYPE_PRIMARY_QUAD_VARJO",
+                    "environment_blend_modes": [
+                        "OPAQUE",
+                        "ALPHA_BLEND"
+                    ]
+                },
+                {
+                    "view_configuration": "XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO",
+                    "environment_blend_modes": [
+                        "OPAQUE",
+                        "ALPHA_BLEND"
+                    ]
+                }
+
+            ]
+        }
     ]
 }


### PR DESCRIPTION
Tried to enhance the supported extension table to enhance readability:

* Added a slanted header to have runtime names on single line (and also have fixed width to columns)
* Made the extension category span the full table width, and center and colorize the row to make it stand out a bit
* Put in check marks and "-" as symbols for supported vs non supported extension
* Removed the grid in the table since it did not look good with the slanted headers (think that checkmarks and "-" gives good support for the eye to follow columns downward).
* Added links from the extensions to the sections in the spec.

Hope it looks ok, adding a screenshot for the update

![image](https://user-images.githubusercontent.com/16424533/221533406-8c6b8e5e-53c8-4393-aabd-f896c66c336f.png)
