### PR TITLE
Corrected Godot Engines official name

### DIFF
--- a/clients/godot.json
+++ b/clients/godot.json
@@ -1,6 +1,6 @@
 {
     "$schema": "../client_schema.json",
-    "name": "Godot Game Engine",
+    "name": "Godot Engine",
     "vendor": "Godot Community",
     "notes": "Some extensions require the use of the Godot OpenXR Vendors Plugin.",
     "platforms": [


### PR DESCRIPTION
Oops, old habit, the Godot Engines official name doesn't have game in it.